### PR TITLE
docs: fix unexpected keyword arguments in random_multilayer_ER

### DIFF
--- a/docfiles/supra.rst
+++ b/docfiles/supra.rst
@@ -9,7 +9,7 @@ Multiplex networks can be represented as supra-adjacency matrices for tensor-bas
     
     # Generate network
     network = random_generators.random_multilayer_ER(
-        num_nodes=500, num_layers=8, probability=0.05, directed=False)
+        n=500, l=8, p=0.05, directed=False)
     
     # Get supra-adjacency matrix
     supra_matrix = network.get_supra_adjacency_matrix()


### PR DESCRIPTION
Hi! As discussed in the issue, this PR fixes the documentation typo in Section 3.8 (`supra.rst`). It updates the parameter names from `num_nodes, num_layers, probability` to` n, l, p` to match the actual function signature and prevent the TypeError.