### PR TITLE
Fix multiplex example

### DIFF
--- a/book/part1_foundations/chapter02_multilayer_basics.rst
+++ b/book/part1_foundations/chapter02_multilayer_basics.rst
@@ -371,24 +371,26 @@ Working with Supra-Adjacency Matrices in Py3plex
 
     from py3plex.core import multinet, random_generators
     
-    # Generate random multilayer network
-    network = random_generators.random_multilayer_ER(
-        num_nodes=100, 
-        num_layers=3, 
-        probability=0.05, 
+    # Generate random multiplex network
+    network = random_generators.random_multiplex_ER(
+        n=100,
+        l=3,
+        p=0.05,
         directed=False
     )
     
     # Get supra-adjacency matrix (sparse format)
     supra_matrix = network.get_supra_adjacency_matrix()
     
-    print(f"Matrix shape: {supra_matrix.shape}")  # (300, 300) for 100 nodes × 3 layers
+    print(f"Matrix shape: {supra_matrix.shape}")  # (300, 300) for 100 nodes replicated across 3 layers
     print(f"Matrix density: {supra_matrix.nnz / (supra_matrix.shape[0] ** 2):.4f}")
     
     # Visualize matrix structure
     network.visualize_matrix({"display": True})
 
 The supra-adjacency matrix enables tensor-based algorithms and linear algebra operations on the full multilayer structure.
+
+Use ``random_multiplex_ER`` when you want the classic :math:`N \times L` node-replica construction with identity coupling between layers. By contrast, ``random_multilayer_ER`` creates a general multilayer network in which each base node is assigned to a single layer, so the supra-adjacency shape is determined by the node-layer pairs that actually exist.
 
 Common Multilayer Semantic Pitfalls
 ------------------------------------

--- a/docfiles/concepts/py3plex_core_model.rst
+++ b/docfiles/concepts/py3plex_core_model.rst
@@ -339,9 +339,9 @@ Visualize the supra-adjacency matrix structure:
     from py3plex.core import multinet, random_generators
     import matplotlib.pyplot as plt
     
-    # Generate a small multilayer network
-    network = random_generators.random_multilayer_ER(
-        num_nodes=50, num_layers=3, probability=0.1, directed=False
+    # Generate a small multiplex network
+    network = random_generators.random_multiplex_ER(
+        n=50, l=3, p=0.1, directed=False
     )
     
     # Visualize the supra-adjacency matrix

--- a/docfiles/supra.rst
+++ b/docfiles/supra.rst
@@ -8,7 +8,7 @@ Multiplex networks can be represented as supra-adjacency matrices for tensor-bas
     from py3plex.core import multinet, random_generators
     
     # Generate network
-    network = random_generators.random_multilayer_ER(
+    network = random_generators.random_multiplex_ER(
         n=500, l=8, p=0.05, directed=False)
     
     # Get supra-adjacency matrix
@@ -43,7 +43,7 @@ You can access nodes and edges using tensor-like indexing:
     from py3plex.core import random_generators
 
     # Initiate an instance of a random graph
-    ER_multilayer = random_generators.random_multilayer_ER(500, 8, 0.05, directed=False)
+    ER_multilayer = random_generators.random_multiplex_ER(500, 8, 0.05, directed=False)
 
     # Some simple visualization
     visualization_params = {"display": True}

--- a/py3plex/core/multinet.py
+++ b/py3plex/core/multinet.py
@@ -382,6 +382,10 @@ def _encode_multiplex_network(core_network):
     import scipy.sparse as sp
 
     unique_layers = sorted({n[1] for n in core_network.nodes()})
+    if not unique_layers:
+        return sp.csr_matrix((0, 0)), []
+
+    base_node_order = list(dict.fromkeys(node[0] for node in core_network.nodes()))
     num_layers = len(unique_layers)
     individual_adj_sparse = []
     all_nodes = []
@@ -390,11 +394,15 @@ def _encode_multiplex_network(core_network):
     # Build sparse adjacency matrix for each layer
     # Using sparse matrices from the start avoids dense intermediate arrays
     for layer in unique_layers:
-        layer_nodes = [n for n in core_network.nodes() if n[1] == layer]
+        layer_nodes = [
+            (base_node, layer)
+            for base_node in base_node_order
+            if (base_node, layer) in core_network
+        ]
         H = core_network.subgraph(layer_nodes)
 
         # Use nx_to_scipy_sparse_matrix for direct sparse conversion
-        adj_sparse = nx_to_scipy_sparse_matrix(H)
+        adj_sparse = nx_to_scipy_sparse_matrix(H, nodelist=layer_nodes)
 
         all_nodes += list(H.nodes())
         individual_adj_sparse.append(adj_sparse)

--- a/py3plex/core/random_generators.py
+++ b/py3plex/core/random_generators.py
@@ -305,6 +305,10 @@ def random_multilayer_ER(
     """
     Generate random multilayer Erdős-Rényi network.
 
+    This generator creates a general multilayer network where each base node is
+    assigned to exactly one layer. As a result, the number of node-layer pairs
+    is typically ``n`` rather than ``n * l``.
+
     Args:
         n: Number of nodes (must be positive)
         l: Number of layers (must be positive)
@@ -369,6 +373,11 @@ def random_multiplex_ER(
     """
     Generate random multiplex Erdős-Rényi network.
 
+    This generator creates a strict multiplex network where all ``n`` base
+    nodes are instantiated in every one of the ``l`` layers. Consequently, the
+    node-layer replica set has size ``n * l`` and the supra-adjacency matrix has
+    shape ``(n * l, n * l)``.
+
     Args:
         n: Number of nodes (must be positive)
         l: Number of layers (must be positive)
@@ -391,6 +400,9 @@ def random_multiplex_ER(
         G = nx.MultiGraph()
 
     for lx in range(l):
+        for node in range(n):
+            G.add_node((node, lx), type="default")
+
         network = nx.fast_gnp_random_graph(n, p, seed=None, directed=directed)
         for edge in network.edges():
             G.add_edge((edge[0], lx), (edge[1], lx), type="default")

--- a/tests/test_random_generators_additional.py
+++ b/tests/test_random_generators_additional.py
@@ -85,6 +85,16 @@ class TestRandomMultilayerER:
         assert network_sparse is not None
         assert network_dense is not None
 
+    def test_multilayer_supra_shape_tracks_present_replicas(self):
+        """General multilayer ER uses one node-layer replica per base node."""
+        n, l, p = 12, 3, 0.4
+        network = random_multilayer_ER(n, l, p)
+
+        supra = network.get_supra_adjacency_matrix()
+
+        assert len(list(network.get_nodes())) == n
+        assert supra.shape == (n, n)
+
 
 class TestRandomMultiplexER:
     """Tests for random_multiplex_ER function."""
@@ -148,6 +158,17 @@ class TestRandomMultiplexER:
         assert hasattr(network, 'core_network')
         G = network.core_network
         assert isinstance(G, (nx.MultiGraph, nx.MultiDiGraph))
+
+    def test_multiplex_preserves_all_node_replicas(self):
+        """Multiplex ER should materialize every node in every layer."""
+        n, l, p = 8, 4, 0.0
+        network = random_multiplex_ER(n, l, p)
+
+        nodes = list(network.get_nodes())
+        supra = network.get_supra_adjacency_matrix()
+
+        assert len(nodes) == n * l
+        assert supra.shape == (n * l, n * l)
 
 
 class TestRandomMultiplexGenerator:


### PR DESCRIPTION
 ## Summary

  Fixes the supra-adjacency docs mismatch reported in #1262 and addresses the underlying multiplex generator behavior that made the documented expectation unreliable.

  This PR does two things:

  1. Fixes the documentation to use the correct generator for a classic multiplex supra-adjacency example.
  2. Fixes random_multiplex_ER() so it always materializes all node replicas across all layers, including isolated ones.

  ## Problem

  The docs example in Section 3.8 expected:

  - 100 nodes
  - 3 layers
  - supra-adjacency shape (300, 300)

  but used random_multilayer_ER(...), which generates a general multilayer network where each base node is assigned to a single layer. In that case, the supra-adjacency size reflects
  the number of node-layer pairs that actually exist, which is typically n, not n * l.

  Separately, random_multiplex_ER(...) did not explicitly add isolated replicas, so even in multiplex mode the supra-adjacency shape was not guaranteed to be exactly n * l when some
  nodes had no incident edges in a layer.

  ## Root cause

  - Docs issue: the example used random_multilayer_ER(...) where random_multiplex_ER(...) was intended.
  - Implementation issue: random_multiplex_ER(...) only added nodes implicitly through edges, so isolated node-layer replicas could be missing.

  ## Changes

  ### Code

  - Update random_multiplex_ER() to add all (node, layer) replicas before adding edges.
  - Make multiplex supra-matrix encoding robust for empty graphs.
  - Use stable base-node ordering during multiplex encoding so layer blocks align consistently.

  ### Docs

  - Update the supra-adjacency example in the book to use random_multiplex_ER(...).
  - Clarify the semantic difference between:
      - random_multilayer_ER(...) → general multilayer, present replicas only
      - random_multiplex_ER(...) → strict multiplex, all n * l replicas

  ### Tests

  - Add regression coverage for:
      - random_multilayer_ER(...) producing a supra shape based on present replicas
      - random_multiplex_ER(...) preserving all replicas even when p=0

  ## Expected behavior after this PR

  - random_multilayer_ER(100, 3, p) produces a supra-adjacency matrix sized by the actual node-layer pairs present.
  - random_multiplex_ER(100, 3, p) produces a supra-adjacency matrix of shape (300, 300).

  ## Validation

  Direct sanity checks confirm:

  - random_multilayer_ER(12, 3, 0.4) → (12, 12)
  - random_multiplex_ER(8, 4, 0.0) → (32, 32)
  - random_multiplex_ER(100, 3, 0.05) → (300, 300)

  ## Closes

  Closes #1262
