### PR TITLE
Implement MDL metric value

### DIFF
--- a/py3plex/algorithms/community_detection/autocommunity_executor.py
+++ b/py3plex/algorithms/community_detection/autocommunity_executor.py
@@ -517,11 +517,16 @@ def _evaluate_algorithms(
                             value = 0.0
                     else:
                         value = 0.0
-                
+
                 elif metric_name == "mdl":
-                    # Description length (if available)
-                    # Placeholder for now
-                    value = 0.0
+                    # Extract from algorithm metadata (SBM algorithms compute this)
+                    # For non-SBM algorithms, this metric is not available
+
+                    meta = result.get('meta', {})
+                    mdl_value = meta.get('mdl')
+                    if mdl_value is None:
+                        mdl_value = meta.get('bic')
+                    value = mdl_value if mdl_value is not None else 0.0
                 
                 elif metric_name == "replica_consistency":
                     # Multilayer coherence metric


### PR DESCRIPTION
## Description

Implements elif metric_name == "mdl": in autocommunity_executor.py.

## Motivation

No placeholder and always 0.0 value.

## Changes

                elif metric_name == "mdl":
                    # Extract from algorithm metadata (SBM algorithms compute this)
                    # For non-SBM algorithms, this metric is not available

                    meta = result.get('meta', {})
                    mdl_value = meta.get('mdl')
                    if mdl_value is None:
                        mdl_value = meta.get('bic')
                    value = mdl_value if mdl_value is not None else 0.0

## Testing

- 'make test' executed, 120 issues found
- 'make lint' executed

## Breaking Changes

None.

## TODO
- Need to check how to implement MDL (if possible) in Louvain/Leiden/Infomap result dicts.
- For Louvain/Leiden/Infomap result.get('meta') returns None because the key is never set, make this consistent.
- Instead of 0.0 when there is no value, return None. Need to see how this would be then used by Pareto.
-  Recheck if meta.get('bic') returns anything, because in runner.py there is no bic value for meta key.