### PR TITLE
Remove unused imports in files in community_detection folder

### DIFF
--- a/py3plex/algorithms/community_detection/autocommunity.py
+++ b/py3plex/algorithms/community_detection/autocommunity.py
@@ -38,16 +38,13 @@ Example Usage:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Callable
-import warnings
 
 import numpy as np
 import pandas as pd
 
 from py3plex.exceptions import AlgorithmError
-from py3plex.uncertainty.partition import CommunityDistribution
-
 
 @dataclass
 class CommunityStats:

--- a/py3plex/algorithms/community_detection/autocommunity_executor.py
+++ b/py3plex/algorithms/community_detection/autocommunity_executor.py
@@ -660,7 +660,7 @@ def _compute_null_model_scores(
                             null_network,
                             seed=seed,
                         )
-                        null_partition = null_leiden.partition
+                        null_partition = null_leiden.communities
                     elif algo_name == "infomap":
                         from py3plex.algorithms.community_detection.community_wrapper import infomap_communities
                         try:

--- a/py3plex/algorithms/community_detection/autocommunity_executor.py
+++ b/py3plex/algorithms/community_detection/autocommunity_executor.py
@@ -517,11 +517,16 @@ def _evaluate_algorithms(
                             value = 0.0
                     else:
                         value = 0.0
-                
+
                 elif metric_name == "mdl":
-                    # Description length (if available)
-                    # Placeholder for now
-                    value = 0.0
+                    # Extract from algorithm metadata (SBM algorithms compute this)
+                    # For non-SBM algorithms, this metric is not available
+
+                    meta = result.get('meta', {})
+                    mdl_value = meta.get('mdl')
+                    if mdl_value is None:
+                        mdl_value = meta.get('bic')
+                    value = mdl_value if mdl_value is not None else 0.0
                 
                 elif metric_name == "replica_consistency":
                     # Multilayer coherence metric

--- a/py3plex/algorithms/community_detection/distributional.py
+++ b/py3plex/algorithms/community_detection/distributional.py
@@ -52,8 +52,6 @@ from py3plex.uncertainty.resampling_graph import (
 )
 from py3plex._parallel import parallel_map, spawn_seeds
 from py3plex.exceptions import AlgorithmError
-from py3plex import config
-
 
 def _run_louvain_single(args: Tuple) -> Tuple[np.ndarray, float, List[Any]]:
     """Worker function for a single Louvain run (module-level for pickling).

--- a/py3plex/algorithms/community_detection/flow_hierarchy.py
+++ b/py3plex/algorithms/community_detection/flow_hierarchy.py
@@ -82,7 +82,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import scipy.sparse as sp
-from scipy.sparse.linalg import eigsh
 
 from py3plex.exceptions import AlgorithmError, Py3plexException
 

--- a/py3plex/algorithms/community_detection/runner.py
+++ b/py3plex/algorithms/community_detection/runner.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import time
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from py3plex.algorithms.community_detection.budget import BudgetSpec, CommunityResult
 

--- a/py3plex/algorithms/community_detection/sbm_wrapper.py
+++ b/py3plex/algorithms/community_detection/sbm_wrapper.py
@@ -6,7 +6,6 @@ compatible with the AutoCommunity framework and DSL integration.
 """
 
 from typing import Any, Dict, List, Optional, Tuple, Union
-import numpy as np
 
 from py3plex.algorithms.sbm import (
     fit_multilayer_sbm,

--- a/py3plex/algorithms/community_detection/successive_halving.py
+++ b/py3plex/algorithms/community_detection/successive_halving.py
@@ -10,7 +10,6 @@ import math
 import time
 import warnings
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np


### PR DESCRIPTION
## Description

- Remove unused imports in files in community_detection folder.
- Write null_leiden.communities instead of null_leiden.partitions, because null_leiden.communities is not correct.

## Motivation

Remove unnecessary stuff and fix.

## Changes

Changes in .py files in folder community_detection.

## Breaking Changes

None.