### PR TITLE
Fixes in parser.py to solve bug in CBSSD

### DIFF
--- a/py3plex/core/parsers.py
+++ b/py3plex/core/parsers.py
@@ -225,7 +225,10 @@ def parse_gpickle(
             except (ValueError, AttributeError):
                 pass
     else:
-        A = G
+        if not isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):
+            A = nx.MultiDiGraph(G) if directed else nx.MultiGraph(G)
+        else:
+            A = G
 
     todrop = []
     for node in A.nodes(data=True):


### PR DESCRIPTION
## Description

Ensured graphs loaded through parse_gpickle() are returned as MultiGraph or MultiDiGraph, consistent with the parser's expected behavior.

## Motivation

Example example_CBSSD.py failed when loading intact02.gpickle because the stored graph was a networkx.Graph, while parse_gpickle() is required to return a MultiGraph or MultiDiGraph.

## Changes

Updated parse_gpickle() in parser.py to normalize loaded graphs to the expected graph type when necessary. Added this code on line 227:
```python
    else:
        if not isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):
            A = nx.MultiDiGraph(G) if directed else nx.MultiGraph(G)
        else:
            A = G`
```

## Testing

Run `make test`

## Breaking Changes

None.