### PR TITLE
Fix/unused imports

### DIFF
--- a/examples/advanced/example_dynamics_core.py
+++ b/examples/advanced/example_dynamics_core.py
@@ -13,7 +13,6 @@ The new classes provide:
 """
 
 import networkx as nx
-import matplotlib.pyplot as plt
 from py3plex.dynamics import (
     RandomWalkDynamics,
     MultiRandomWalkDynamics,

--- a/examples/advanced/example_embedding_construction.py
+++ b/examples/advanced/example_embedding_construction.py
@@ -26,7 +26,6 @@ SKIP_CI: external_deps - Requires specific dataset files (cora.gml)
 
 import os
 import json
-import tempfile
 from py3plex.core import multinet
 from py3plex.wrappers import train_node2vec_embedding
 from py3plex.visualization.embedding_visualization import embedding_visualization

--- a/examples/advanced/example_graph_program.py
+++ b/examples/advanced/example_graph_program.py
@@ -15,7 +15,7 @@ Run with:
 
 import json
 from py3plex.dsl import Q, L
-from py3plex.dsl.program import GraphProgram, compose
+from py3plex.dsl.program import GraphProgram
 from py3plex.core import multinet
 
 

--- a/examples/advanced/example_multiplex_dynamics.py
+++ b/examples/advanced/example_multiplex_dynamics.py
@@ -91,7 +91,6 @@ for enx, time_slice in enumerate(partial_slices):
                                 edge_size=0.01)
         multilayer_network.remove_layer_edges()  # clean the slice edges
 plt.show()
-# plt.savefig("../images/temporal.png",dpi=300)
 sns.set_style("whitegrid")
 clx = {"RT": "red", "MT": "green", "RE": "blue"}
 
@@ -99,7 +98,7 @@ plt.subplot(1, 1, 1)
 plt.title("Temporal edge dynamics")
 slices = []
 for k, v in num_edges.items():
-    sns.lineplot(list(range(len(v))), v, label=k, color=clx[k])
+    sns.lineplot(x=list(range(len(v))), y=v, label=k, color=clx[k])
 plt.legend()
 plt.xlabel("Time slice")
 plt.ylabel("Number of edges")

--- a/examples/advanced/example_network_decomposition.py
+++ b/examples/advanced/example_network_decomposition.py
@@ -48,5 +48,5 @@ for decomposition in multilayer_network.get_decomposition():
 
 # construct a single dataframe while remaining compatible with lightweight stubs
 if result_frames:
-    validation_results = pd.DataFrame(result_frames)
+    validation_results = pd.concat(result_frames, ignore_index=True)
 print(validation_results)

--- a/py3plex/algorithms/network_classification/label_propagation.py
+++ b/py3plex/algorithms/network_classification/label_propagation.py
@@ -43,6 +43,7 @@ def normalize_initial_matrix_freq(mat: np.ndarray) -> np.ndarray:
         Normalized matrix
     """
     sums = np.sum(mat, axis=0)
+    sums[sums == 0] = 1
     mat = mat / sums
     return mat
 
@@ -209,8 +210,8 @@ def validate_label_propagation(
                     predictions.append(a)
 
                 predicted_labels = np.asarray(predictions)[X_test]
-                micro = f1_score(true_labels, predicted_labels, average="micro")
-                macro = f1_score(true_labels, predicted_labels, average="macro")
+                micro = f1_score(true_labels, predicted_labels, average="micro", zero_division=0)
+                macro = f1_score(true_labels, predicted_labels, average="macro", zero_division=0)
                 end = time.time()
                 elapsed = end - start
                 micros.append(micro)

--- a/py3plex/visualization/multilayer.py
+++ b/py3plex/visualization/multilayer.py
@@ -107,9 +107,6 @@ def _preprocess_network(
     if verbose:
         logger.info(nx_info(network))
 
-    # Calculate degrees
-    degrees = dict(nx.degree(nx.Graph(network)))
-
     # Remove nodes without positions
     no_position = []
     for node in network.nodes(data=True):
@@ -122,6 +119,9 @@ def _preprocess_network(
 
     # Get positions
     positions = nx.get_node_attributes(network, "pos")
+
+    # Calculate degrees after node removal so sizes align with the final nodelist
+    degrees = dict(nx.degree(nx.Graph(network)))
 
     return network, positions, degrees
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,10 @@ dgl_compat = [
 mcp = [
     "mcp>=0.9.0; python_version>='3.10'",
 ]
+# Optional: Dependencies for running advanced examples
+examples = [
+    "sympy>=1.9",
+]
 # Convenience meta-extra for common optional features (without heavy ML backends)
 optional = [
     "infomap>=2.0.0",
@@ -132,6 +136,7 @@ optional = [
     "pyyaml>=5.1",
     "pyarrow>=10.0.0",
     "mcp>=0.9.0; python_version>='3.10'",
+    "sympy>=1.9",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

Small fixes in first half of examples/advanced/ folder. Removed unused modules/imports and fixed some bugs.

## Motivation

Bugs and unused imports.

## Changes

- Removed unused imports.
- Fixed error in example_multiplex_dynamics.py to match newest version of sns: `sns.lineplot(x=list(range(len(v))), y=v, label=k, color=clx[k])`.
- Fixed error in multilayer.py to count exact degrees after nodes removal: `degrees = dict(nx.degree(nx.Graph(network)))`
- Fixed warnings in example_network_decomposition.py: `validation_results = pd.concat(result_frames, ignore_index=True)`.
- To fix warnings in example_network_decomposition.py added this to label_propagation.py: `micro = f1_score(true_labels, predicted_labels, average="micro", zero_division=0)` and `sums[sums == 0] = 1`.
- Added info in pyproject.toml that `sympy` and `primerange` should be installed (idk if I should have done this, however it doesn't change anything anyway).

## Testing

`make test`

## Breaking Changes

None.