### PR TITLE
Fix/unused imports part 2

### DIFF
--- a/examples/advanced/example_dynamics_core.py
+++ b/examples/advanced/example_dynamics_core.py
@@ -13,7 +13,6 @@ The new classes provide:
 """
 
 import networkx as nx
-import matplotlib.pyplot as plt
 from py3plex.dynamics import (
     RandomWalkDynamics,
     MultiRandomWalkDynamics,

--- a/examples/advanced/example_embedding_construction.py
+++ b/examples/advanced/example_embedding_construction.py
@@ -26,7 +26,6 @@ SKIP_CI: external_deps - Requires specific dataset files (cora.gml)
 
 import os
 import json
-import tempfile
 from py3plex.core import multinet
 from py3plex.wrappers import train_node2vec_embedding
 from py3plex.visualization.embedding_visualization import embedding_visualization

--- a/examples/advanced/example_graph_program.py
+++ b/examples/advanced/example_graph_program.py
@@ -15,7 +15,7 @@ Run with:
 
 import json
 from py3plex.dsl import Q, L
-from py3plex.dsl.program import GraphProgram, compose
+from py3plex.dsl.program import GraphProgram
 from py3plex.core import multinet
 
 

--- a/examples/advanced/example_multiplex_dynamics.py
+++ b/examples/advanced/example_multiplex_dynamics.py
@@ -91,7 +91,6 @@ for enx, time_slice in enumerate(partial_slices):
                                 edge_size=0.01)
         multilayer_network.remove_layer_edges()  # clean the slice edges
 plt.show()
-# plt.savefig("../images/temporal.png",dpi=300)
 sns.set_style("whitegrid")
 clx = {"RT": "red", "MT": "green", "RE": "blue"}
 
@@ -99,7 +98,7 @@ plt.subplot(1, 1, 1)
 plt.title("Temporal edge dynamics")
 slices = []
 for k, v in num_edges.items():
-    sns.lineplot(list(range(len(v))), v, label=k, color=clx[k])
+    sns.lineplot(x=list(range(len(v))), y=v, label=k, color=clx[k])
 plt.legend()
 plt.xlabel("Time slice")
 plt.ylabel("Number of edges")

--- a/examples/advanced/example_network_decomposition.py
+++ b/examples/advanced/example_network_decomposition.py
@@ -48,5 +48,5 @@ for decomposition in multilayer_network.get_decomposition():
 
 # construct a single dataframe while remaining compatible with lightweight stubs
 if result_frames:
-    validation_results = pd.DataFrame(result_frames)
+    validation_results = pd.concat(result_frames, ignore_index=True)
 print(validation_results)

--- a/examples/advanced/example_ricci_curvature.py
+++ b/examples/advanced/example_ricci_curvature.py
@@ -125,8 +125,6 @@ try:
 
 except Exception as e:
     print(f"\n Error computing curvature: {e}")
-    import traceback
-    traceback.print_exc()
 
 # ============================================================================
 # Example 2: Compute Curvature Per Layer

--- a/examples/advanced/example_spreading.py
+++ b/examples/advanced/example_spreading.py
@@ -118,15 +118,13 @@ for simulation_id in range(num_simulations):
 
     # Visualize layer visit distribution
     if layer_visit_sequence:
-        sns.distplot(
+        sns.histplot(
             layer_visit_sequence,
             bins=10,
             kde=True,
             label=f"Walker {simulation_id + 1}",
-            hist_kws={
-                "linewidth": 3,
-                "alpha": 0.2
-            }
+            linewidth=3,
+            alpha=0.2,
         )
 
 print("\n" + "=" * 70)

--- a/py3plex/algorithms/network_classification/PPR.py
+++ b/py3plex/algorithms/network_classification/PPR.py
@@ -70,7 +70,7 @@ def validate_ppr(
     if multiclass_classifier is None:
         multiclass_classifier = SVC(kernel="linear", C=1, probability=True)
 
-    df = pd.DataFrame()
+    rows = []
     for _k in range(repetitions):
 
         # this is relevant for supra-adjacency-based tasks..
@@ -142,7 +142,7 @@ def validate_ppr(
                 "dataset": dataset_name,
                 "time": np.mean(times),
             }
-            df = df.append(outarray, ignore_index=True)
+            rows.append(outarray)
 
-    df = df.reset_index()
+    df = pd.DataFrame(rows).reset_index()
     return df

--- a/py3plex/algorithms/network_classification/label_propagation.py
+++ b/py3plex/algorithms/network_classification/label_propagation.py
@@ -43,6 +43,7 @@ def normalize_initial_matrix_freq(mat: np.ndarray) -> np.ndarray:
         Normalized matrix
     """
     sums = np.sum(mat, axis=0)
+    sums[sums == 0] = 1
     mat = mat / sums
     return mat
 
@@ -209,8 +210,8 @@ def validate_label_propagation(
                     predictions.append(a)
 
                 predicted_labels = np.asarray(predictions)[X_test]
-                micro = f1_score(true_labels, predicted_labels, average="micro")
-                macro = f1_score(true_labels, predicted_labels, average="macro")
+                micro = f1_score(true_labels, predicted_labels, average="micro", zero_division=0)
+                macro = f1_score(true_labels, predicted_labels, average="macro", zero_division=0)
                 end = time.time()
                 elapsed = end - start
                 micros.append(micro)

--- a/py3plex/core/multinet.py
+++ b/py3plex/core/multinet.py
@@ -58,7 +58,9 @@ try:
     RICCI_AVAILABLE = True
 except ImportError:
     RICCI_AVAILABLE = False
-    RicciBackendNotAvailable = None
+
+    class RicciBackendNotAvailable(ImportError):
+        pass
 
 # Mapping of sparse matrix format names to conversion method names (for get_tensor)
 SPARSE_FORMAT_METHODS = {
@@ -3978,7 +3980,7 @@ class multi_layer_network:
             >>> result = net.compute_ollivier_ricci(mode="supra", inplace=False)  # doctest: +SKIP
         """
         if not RICCI_AVAILABLE:
-            raise RicciBackendNotAvailable()
+            raise RicciBackendNotAvailable("GraphRicciCurvature is not installed. Install with: pip install GraphRicciCurvature")
 
         if mode not in ["core", "layers", "supra"]:
             raise ValueError(f"Invalid mode: {mode}. Must be 'core', 'layers', or 'supra'.")
@@ -4132,7 +4134,7 @@ class multi_layer_network:
             >>> result = net.compute_ollivier_ricci_flow(mode="layers", iterations=10)  # doctest: +SKIP
         """
         if not RICCI_AVAILABLE:
-            raise RicciBackendNotAvailable()
+            raise RicciBackendNotAvailable("GraphRicciCurvature is not installed. Install with: pip install GraphRicciCurvature")
 
         if mode not in ["core", "layers", "supra"]:
             raise ValueError(f"Invalid mode: {mode}. Must be 'core', 'layers', or 'supra'.")

--- a/py3plex/visualization/benchmark_visualizations.py
+++ b/py3plex/visualization/benchmark_visualizations.py
@@ -19,12 +19,12 @@ def plot_core_macro(fname: pd.DataFrame) -> int:
     A very simple visualization of the results..
     """
     sns.pointplot(
-        "percent_train",
-        "macro_F",
+        x="percent_train",
+        y="macro_F",
         hue="setting",
         data=fname,
         markers=["p"] * 10,
-        ci="sd",
+        errorbar="sd",
         linestyles=["-", "--", "-.", ":"] * 5,
     )
     plt.show()
@@ -36,7 +36,7 @@ def plot_core_micro(fname: pd.DataFrame) -> int:
     """
     A very simple visualization of the results..
     """
-    sns.lineplot("percent_train", "micro_F", hue="setting", data=fname)
+    sns.lineplot(x="percent_train", y="micro_F", hue="setting", data=fname)
     plt.show()
 
     return 1
@@ -53,7 +53,7 @@ def plot_core_macro_box(fname: str) -> int:
     fnamex.columns = cnames
     logger.debug("DataFrame head:\n%s", fnamex.head())
 
-    sns.boxplot("percent_train", "macro_F", hue="setting", data=fnamex)
+    sns.boxplot(x="percent_train", y="macro_F", hue="setting", data=fnamex)
     plt.show()
     return 1
 
@@ -128,7 +128,7 @@ def plot_core_time(fnamex: pd.DataFrame) -> int:
 
     fnamex.columns = cnames
     logger.debug("DataFrame head:\n%s", fnamex.head())
-    sns.boxplot("setting", "time", data=fnamex)
+    sns.boxplot(x="setting", y="time", data=fnamex)
     plt.show()
     return 1
 
@@ -236,12 +236,12 @@ def plot_robustness(infile: pd.DataFrame) -> None:
     logger.debug("Input DataFrame head:\n%s", infile.head())
     #    infile['percent_train'] = pd.to_numeric(infile['percent_train'])
     infile = infile[infile["percent_train"] < 0.6]
-    p1 = sns.boxplot("percent_train", "macro_F", data=infile)
+    p1 = sns.boxplot(x="percent_train", y="macro_F", data=infile)
     p1.set_xlabel("Train percent", fontsize=20)
     p1.set_ylabel("Macro F score", fontsize=20)
     plt.show()
 
-    p1 = sns.boxplot("percent_train", "micro_F", data=infile)
+    p1 = sns.boxplot(x="percent_train", y="micro_F", data=infile)
     p1.set_xlabel("Train percent", fontsize=20)
     p1.set_ylabel("Micro F score", fontsize=20)
     plt.show()

--- a/py3plex/visualization/multilayer.py
+++ b/py3plex/visualization/multilayer.py
@@ -107,9 +107,6 @@ def _preprocess_network(
     if verbose:
         logger.info(nx_info(network))
 
-    # Calculate degrees
-    degrees = dict(nx.degree(nx.Graph(network)))
-
     # Remove nodes without positions
     no_position = []
     for node in network.nodes(data=True):
@@ -122,6 +119,9 @@ def _preprocess_network(
 
     # Get positions
     positions = nx.get_node_attributes(network, "pos")
+
+    # Calculate degrees after node removal so sizes align with the final nodelist
+    degrees = dict(nx.degree(nx.Graph(network)))
 
     return network, positions, degrees
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,10 @@ dgl_compat = [
 mcp = [
     "mcp>=0.9.0; python_version>='3.10'",
 ]
+# Optional: Dependencies for running advanced examples
+examples = [
+    "sympy>=1.9",
+]
 # Convenience meta-extra for common optional features (without heavy ML backends)
 optional = [
     "infomap>=2.0.0",
@@ -132,6 +136,7 @@ optional = [
     "pyyaml>=5.1",
     "pyarrow>=10.0.0",
     "mcp>=0.9.0; python_version>='3.10'",
+    "sympy>=1.9",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

Finished checks in whole examples/advanced/ folder. 
Fix bugs and align with latest versions of modules and libs.

## Motivation

Fix bugs and align with latest versions of modules and libs.

## Changes

Changes in: 
- PPR.py
fixed `df = pd.DataFrame(rows).reset_index()` syntax.
- benchmark_visualisations.py:
fixed `sns.pointplot` syntax.
- example_ricci_curvature.py: 
managed exeption output error `import traceback
 traceback.print_exc()`.
- multinet.py: 
managed exeption output`class RicciBackendNotAvailable(ImportError):
        pass`, `raise RicciBackendNotAvailable("GraphRicciCurvature is not installed. Install with: pip install GraphRicciCurvature")`
- example_spreading.py:
changed `sns.distplot` to `sns.histplot` to match current version

## Testing

`make test`

## Breaking Changes

None.